### PR TITLE
Extract a value object to handle prefer headers.

### DIFF
--- a/lib/ldp/client.rb
+++ b/lib/ldp/client.rb
@@ -4,6 +4,7 @@ module Ldp
   class Client
 
     require 'ldp/client/methods'
+    require 'ldp/client/prefer_headers'
     include Ldp::Client::Methods
 
     def initialize *http_client

--- a/lib/ldp/client/prefer_headers.rb
+++ b/lib/ldp/client/prefer_headers.rb
@@ -1,0 +1,64 @@
+module Ldp
+  class PreferHeaders
+    attr_reader :headers_string
+
+    def initialize(headers_string="")
+      @headers_string = headers_string
+    end
+
+    def omit
+      @omit ||= options["omit"] || []
+    end
+
+    def include
+      @include ||= options["include"] || []
+    end
+
+    def return
+      @return ||= options["return"].first || ""
+    end
+
+    def include=(vals)
+      @include = Array(vals)
+      serialize
+    end
+
+    def omit=(vals)
+      @omit = Array(vals)
+      serialize
+    end
+
+    def return=(vals)
+      @return = Array(vals).first
+      serialize
+    end
+
+    def to_s
+      headers_string.to_s
+    end
+
+    private
+
+    def serialize
+      head_string = []
+      unless self.return.empty?
+        head_string << "return=#{self.return}"
+      end
+      unless omit.empty?
+        head_string << "omit=\"#{omit.join(" ")}\""
+      end
+      unless self.include.empty?
+        head_string << "include=\"#{self.include.join(" ")}\""
+      end
+      @headers_string = head_string.join("; ")
+    end
+
+    def options
+      headers_string.gsub('"',"").
+        split(";").
+        map{|x| x.strip.split("=")}.
+        map{|x| { x[0] => x[1].split(" ") }}.
+        inject({}, &:merge)
+    end
+  end
+end

--- a/spec/lib/ldp/client/prefer_headers_spec.rb
+++ b/spec/lib/ldp/client/prefer_headers_spec.rb
@@ -1,0 +1,67 @@
+require 'spec_helper'
+
+RSpec.describe Ldp::PreferHeaders do
+  let(:header_string) { "return=representation; omit=\"http://1.1.1 http://2.3/b\"; include=\"http://2.2.2\"" }
+  subject { described_class.new(header_string) }
+
+  describe "#return" do
+    it "should return what's being returned" do
+      expect(subject.return).to eq "representation"
+    end
+  end
+
+  describe "#omit" do
+    it "should return omit array" do
+      expect(subject.omit).to eq ["http://1.1.1", "http://2.3/b"]
+    end
+  end
+
+  describe "#include" do
+    it "should return include array" do
+      expect(subject.include).to eq ["http://2.2.2"]
+    end
+  end
+
+  describe "#include=" do
+    it "should set include" do
+      subject.include = ["http://3.3.3", "http://1.1.1"]
+      
+      expect(subject.include).to eq ["http://3.3.3", "http://1.1.1"]
+      expect(subject.to_s).to eq "return=representation; omit=\"http://1.1.1 http://2.3/b\"; include=\"http://3.3.3 http://1.1.1\""
+    end
+    it "should be able to set a single value" do
+      subject.include = "http://3.3.3"
+      expect(subject.to_s).to eq "return=representation; omit=\"http://1.1.1 http://2.3/b\"; include=\"http://3.3.3\""
+    end
+    context "when set to nothing" do
+      it "should not serialize that value" do
+        subject.include = []
+        expect(subject.to_s).to eq "return=representation; omit=\"http://1.1.1 http://2.3/b\""
+      end
+    end
+  end
+
+  describe "#return=" do
+    it "should set return" do
+      subject.return = "bananas"
+
+      expect(subject.return).to eq "bananas"
+      expect(subject.to_s).to eq "return=bananas; omit=\"http://1.1.1 http://2.3/b\"; include=\"http://2.2.2\""
+    end
+  end
+
+  describe "#omit=" do
+    it "should set omit" do
+      subject.omit = ["http://3.3.3", "http://1.1.1"]
+
+      expect(subject.omit).to eq ["http://3.3.3", "http://1.1.1"]
+      expect(subject.to_s).to eq "return=representation; omit=\"http://3.3.3 http://1.1.1\"; include=\"http://2.2.2\""
+    end
+    context "when set to nothing" do
+      it "should not serialize that value" do
+        subject.omit = []
+        expect(subject.to_s).to eq "return=representation; include=\"http://2.2.2\""
+      end
+    end
+  end
+end


### PR DESCRIPTION
Generating this was complicated enough that it'd be useful to use in other
applications, like ActiveFedora.