### PR TITLE
Remove unnecessary require

### DIFF
--- a/lib/ldp/resource/rdf_source.rb
+++ b/lib/ldp/resource/rdf_source.rb
@@ -1,5 +1,4 @@
 require 'rdf/turtle'
-require 'rdf/rdfxml'
 module Ldp
   class Resource::RdfSource < Ldp::Resource
 


### PR DESCRIPTION
This is important because we haven't declared rdfxml as a dependency.