### PR TITLE
Avoid an instantiation if subject is already a RDF::URI

### DIFF
--- a/lib/ldp/resource.rb
+++ b/lib/ldp/resource.rb
@@ -27,7 +27,7 @@ module Ldp
     ##
     # Get the graph subject as a URI
     def subject_uri
-      @subject_uri ||= RDF::URI.new subject
+      @subject_uri ||= RDF::URI(subject)
     end
 
     ##


### PR DESCRIPTION
This prevents a deprecation warning like:
```
[DEPRECATION] URI#to_hash is deprecated, use URI#to_h instead. Called
from
/home/travis/build/projecthydra-labs/hyku/vendor/bundle/ruby/2.3.0/gems/ldp-0.6.2/lib/ldp/resource.rb:30
```