### PR TITLE
Raise Ldp::Conflict when creating existing resource

### DIFF
--- a/lib/ldp/resource.rb
+++ b/lib/ldp/resource.rb
@@ -77,8 +77,9 @@ module Ldp
     ##
     # Create a new resource at the URI
     # @return [RdfSource] the new representation
+    # @raise [Ldp::Conflict] if you attempt to call create on an existing resource
     def create &block
-      raise Ldp::Error, "Can't call create on an existing resource" unless new?
+      raise Ldp::Conflict, "Can't call create on an existing resource" unless new?
       verb = subject.nil? ? :post : :put
       resp = client.send(verb, (subject || @base_path), content) do |req|
         req.headers["Link"] = "<#{interaction_model}>;rel=\"type\"" if interaction_model

--- a/spec/lib/ldp/resource/rdf_source_spec.rb
+++ b/spec/lib/ldp/resource/rdf_source_spec.rb
@@ -1,5 +1,6 @@
 require 'stringio'
 require 'spec_helper'
+require 'rdf/vocab/dc'
 
 describe Ldp::Resource::RdfSource do
   let(:simple_graph) do
@@ -34,7 +35,18 @@ describe Ldp::Resource::RdfSource do
 
 
   describe "#create" do
-    subject { Ldp::Resource::RdfSource.new mock_client, nil }
+    subject { rdf_source }
+    let(:rdf_source) { Ldp::Resource::RdfSource.new mock_client, nil }
+
+    context "if the resource already exists" do
+      subject { rdf_source.create }
+      before do
+        allow(rdf_source).to receive(:new?).and_return(false)
+      end
+      it "raises an error" do
+        expect { subject }.to raise_error Ldp::Conflict
+      end
+    end
 
     it "should return a new resource" do
       created_resource = subject.create


### PR DESCRIPTION
This error aligns the exception with the one you would get if you manage
to have two requests create at the same time and fedora raises a
409 Conflict error.

Ref https://github.com/projecthydra-labs/hyku/issues/755
Ref https://github.com/projecthydra-labs/hyku/issues/751